### PR TITLE
Some books will have series and number information

### DIFF
--- a/database/src/entries.bib
+++ b/database/src/entries.bib
@@ -16,6 +16,7 @@
   author                      = noam.chomsky,
   title                       = {Knowledge of Language},
   subtitle                    = {Its Nature, Origin, and Use},
+  series                      = {Convergence},
   date                        = {1986},
   keywords                    = {syntax, language acquisition, binding theory},
   isbn                        = {0275900258},

--- a/release/lingbib-master.bib
+++ b/release/lingbib-master.bib
@@ -74,6 +74,20 @@
   keywords                    = {DP hypothesis, gerunds, noun phrase, determiner phrase}
 }
 
+@Book{                          chomsky1986:knowledge,
+  author                      = noam.chomsky,
+  title                       = {Knowledge of Language},
+  subtitle                    = {Its Nature, Origin, and Use},
+  series                      = {Convergence},
+  date                        = {1986},
+  keywords                    = {syntax, language acquisition, binding theory},
+  isbn                        = {0275900258},
+  langid                      = {american},
+  location                    = {New York, NY},
+  publisher                   = {Praeger},
+  sortname                    = noam.chomsky
+}
+
 @Article{                       chomsky2013:projection,
   abstract                    = {With the crystallization of the ``generative enterprise'' half a century ago, two concepts became salient: the initial state and final states of the language faculty, respectively, UG (the genetic component) and I-languages. Since then inquiry has gained far greater scope and depth. It has also led to sharpening of fundamental principles of language. At first, descriptive adequacy appeared to require rich and complex assumptions about UG. A primary goal has always been to overcome this deficiency. Core properties of concern have included compositionality, order, projection (labeling), and displacement. Early work assigned the first three to phrase structure rules and the last to the transformational component. Simplification of computational procedures suggests that compositionality and displacement (along with the ``copy theory'') fall together while order may be a reflex of sensorimotor externalization, conclusions that have far-reaching consequences. As for labeling, minimal computation restricts options to the few that have considerable empirical support.},
   author                      = noam.chomsky,

--- a/resources/database_rules.json
+++ b/resources/database_rules.json
@@ -1,6 +1,6 @@
 {
     "entry-fields":{
-        "biblatex":["abstract", "author", "date", "doi", "editor", "eprint", "eprinttype", "ids", "indexsorttitle", "indextitle", "institution", "isbn", "issn", "issue", "issuesubtitle", "issuetitle", "journalsubtitle", "journaltitle", "keywords", "langid", "location", "mainsubtitle", "maintitle", "number", "pages", "publisher", "shortjournal", "shorttitle", "sortname", "subtitle", "title", "type", "volume", "xdata"],
+        "biblatex":["abstract", "author", "date", "doi", "editor", "eprint", "eprinttype", "ids", "indexsorttitle", "indextitle", "institution", "isbn", "issn", "issue", "issuesubtitle", "issuetitle", "journalsubtitle", "journaltitle", "keywords", "langid", "location", "mainsubtitle", "maintitle", "number", "pages", "publisher", "series", "shortjournal", "shorttitle", "sortname", "subtitle", "title", "type", "volume", "xdata"],
         "lingbib": ["keyoverride", "titlekeyword", "xdatatype"]
         },
     "entry-metatypes": {
@@ -23,7 +23,7 @@
         "book": {
             "metatype": "regular-work",
             "required": ["isbn", "publisher", "location"],
-            "if-applicable": null
+            "if-applicable": ["series", "number"] 
         },
         "thesis": {
             "metatype": "regular-work",


### PR DESCRIPTION
*Knowledge of Language* was printed in the Convergence series. It's unclear what number in the series it was, but this will be clear in some cases. If you look at the Amazon preview of the book [here](http://www.amazon.com/Knowledge-Language-Nature-Origins-Convergence/dp/0275917614), there's a page in the frontmatter that says "Books in the Convergence Series" which suggests that it might be number 2 in the series, but I'm a bit loathe to add this without more definitive evidence.

Nonetheless, I think we still should include the series information (but not the number information if we're not entirely sure). Whether the name of the series should be printed in the bibliography if the number information is missing is a question that we can hopefully address if this working group that Kai has mentioned gets off the ground (I would think perhaps not).

What do you think, @khanson679?

As far as the fact that USS doesn't seem to have the longer form of locations for books seems a bit odd and inconsistent with the fact that they want that information in the case of dissertations, for example. I think I agree with your decision to keep the information. This is another decision of the USS that I think ought to be overruled.