### PR TITLE
Reformatted document.

### DIFF
--- a/tests/UnifiedConformityTesting/UnifiedConformityTesting.tex
+++ b/tests/UnifiedConformityTesting/UnifiedConformityTesting.tex
@@ -57,6 +57,17 @@
 
 \newcommand*{\Package}[1]{\texttt{#1}}
 
+\newcommand*{\bibentrytest}[2]{
+	% target output
+	\begin{hangparas}{15pt}{1}
+	#1
+	\end{hangparas}
+	
+	% test entry
+	\nocite{#2}
+	\printbibliography[heading=none]
+}
+
 \title{Testing document for checking conformity to the \UnifiedStyleSheet}
 \author{\Lingbib}
 \date{Last updated: \today}
@@ -69,55 +80,33 @@
 
 \begin{abstract}
 This is a testing document for checking whether entries in the \Lingbib{} database will be formatted in accordance with the guidelines in the \UnifiedStyleSheet{} when printed in a \LaTeX{} document using  \SP' \href{https://github.com/semprag/biblatex-sp-unified/}{\Package{biblatex} implementation of the Unified Stylesheet for Linguistics (\Package{biblatex-sp-unified})}.
+
+For each test case, the target output is directly followed by the test output.
 \end{abstract}
 
 
 
 \section{Journal articles}
 
-\subsection{Exemplars}
+\subsection{Ordinary article}
 
-\begin{hangparas}{15pt}{1}
-
-Iverson, Gregory K. 1983. Korean /s/. \textit{Journal of Phonetics} 11. 191--200.
-
-Iverson, Gregory K. 1989. On the category supralaryngeal. \textit{Phonology} 6. 285--303.
-
-Johson, Kyle, Mark Baker \& Ian Roberts. 1989. Passive arguments raised. \textit{Linguistic Inquiry} 20. 219--251.
-
-Murray, Robert W. \& Theo Vennemann. 1983. Sound change and syllable structure in Germanic phonology. \textit{Language} 59(3). 514--528.
-
-\end{hangparas}
-
-\subsection{Output of \Lingbib{} database + \SPUnified}
-
-\nocite{chomsky2013:projection}
-
-\printbibliography[
-	heading=none
-]
+\bibentrytest{
+	Chomsky, Noam. 2013. \textit{Problems of projection}. \textit{Lingua} 130(1). 33--49.
+	}{
+	chomsky2013:projection
+}
 
 
 
-\section{Dissertations}
+\section{Theses and Dissertations}
 
-\subsection{Exemplars}
+\subsection{PhD Thesis}
 
-\begin{hangparas}{15pt}{1}
-
-Stewart, Thomas W., Jr. 2000. \textit{Mutation as morphology: Bases, stems, and shapes in Scottish Gaelic}. Columbus, OH: The Ohio State University dissertation.
-
-Yu, Alan C.~L. 2003. \textit{The morphology and phonology of infixation}. Berkeley, CA: University of California dissertation.
-
-\end{hangparas}
-
-\subsection{Output of \Lingbib{} database + \SPUnified}
-
-\nocite{munn1993:coordinate}
-
-\printbibliography[
-	heading=none
-]
+\bibentrytest{
+	Munn, Alan Boag. 1993. \textit{Topics in the syntax and semantics of coordinate structures}. College Park, MD: University of Maryland PhD thesis.
+}{
+munn1993:coordinate
+}
 
 
 


### PR DESCRIPTION
Each section now consists of test cases, each with target output immediately
followed by test output.