### PR TITLE
Convert names to YAML format

### DIFF
--- a/database/yaml-src/people.yaml
+++ b/database/yaml-src/people.yaml
@@ -1,0 +1,47 @@
+# People
+---
+
+alan_munn: &alan_munn
+  first: Alan
+  middle: Boag
+  last: Munn
+  lineage: ""
+  sortname: Munn, Alan 
+  url: "https://msu.edu/~amunn/"
+  orcid: ""
+
+cristina_schmitt: &cristina_schmitt
+  first: Cristina
+  middle: Job
+  last: Schmitt
+  lineage: ""
+  sortname: Schmitt, Cristina
+  url: "http://msuacquisition.wordpress.com/"
+  orcid: ""
+
+hagit_borer: &hagit_borer
+  first: Hagit
+  middle: ""
+  last: Borer
+  lineage: ""
+  sortname: Borer, Hagit
+  url: "http://webspace.qmul.ac.uk/hborer/"
+  orcid: ""
+
+noam_chomsky: &noam_chomsky
+  first: Noam
+  middle: ""
+  last: Chomsky
+  lineage: ""
+  sortname: Chomsky, Noam
+  url: "http://web.mit.edu/linguistics/people/faculty/chomsky/"
+  orcid: ""
+
+steven_abney: &steven_abney
+  first: Steven
+  middle: Paul
+  last: Abney
+  lineage: ""
+  sortname: Abney, Steven
+  url: "http://www.vinartus.net/spa/index.html"
+  orcid: ""


### PR DESCRIPTION
Sorry for the delay, @khanson679. I got sick, but this is a start to the conversion process to YAML.

What do you think? I think if we do get a web front-end up running, it would be nice to have URLs and/or [ORCID](https://en.wikipedia.org/wiki/ORCID) IDs so that we could link to the authors. Hence, I've included them.

From my understanding, in order to use YAML's anchor and alias features, everything needs to be in the same file, so I think in order to use the aliases (e.g., &noam_chomsky), everything will need to be concatenated before building the database.

Is this how you think we should do this, or should I omit the aliases?